### PR TITLE
Update matches help text with correct registration command

### DIFF
--- a/cogs/matches.py
+++ b/cogs/matches.py
@@ -61,7 +61,7 @@ class MatchesCog(commands.Cog):
         alias_input = clean_text(target)
         if not alias_input:
             await inter.response.send_message(
-                "별명을 입력해 주세요. 먼저 `/register` 명령으로 Riot ID를 등록할 수 있습니다.",
+                "별명을 입력해 주세요. 먼저 `/별명등록` 명령으로 Riot ID를 등록할 수 있습니다.",
                 ephemeral=True,
             )
             return


### PR DESCRIPTION
## Summary
- update the matches command guidance to reference the correct `/별명등록` command for alias registration

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916cacfab94832d964000296be5bf3f)