### PR TITLE
Add common Riot player info helper and refactor cogs

### DIFF
--- a/cogs/matches.py
+++ b/cogs/matches.py
@@ -6,6 +6,7 @@ from discord import app_commands
 from discord.app_commands import locale_str
 from discord.ext import commands
 
+from core.api import fetch_player_info
 from core.config import HENRIK_BASE
 from core.http import http_get
 from core.store import get_alias, search_aliases, store_match_batch
@@ -83,10 +84,8 @@ class MatchesCog(commands.Cog):
 
         await inter.response.defer()
         try:
-            acc = await http_get(f"{HENRIK_BASE}/v1/account/{q(name)}/{q(tag)}")
-            puuid = (acc.get("data") or {}).get("puuid")
-            if not puuid:
-                raise RuntimeError("Puuid missing in HenrikDev response")
+            info = await fetch_player_info(name, tag, region=region)
+            puuid = info["puuid"]
 
             params = {"size": str(count)}
             if mode:

--- a/cogs/profile.py
+++ b/cogs/profile.py
@@ -5,8 +5,7 @@ from discord import app_commands
 from discord.app_commands import locale_str
 from discord.ext import commands
 
-from core.config import HENRIK_BASE
-from core.http import http_get
+from core.api import fetch_player_info
 from core.store import get_alias, search_aliases
 from core.utils import (
     alias_display,
@@ -14,7 +13,6 @@ from core.utils import (
     clean_text,
     format_exception_message,
     is_account_not_found_error,
-    q,
 )
 
 
@@ -61,14 +59,12 @@ class ProfileCog(commands.Cog):
 
         await inter.response.defer()
         try:
-            acc = await http_get(f"{HENRIK_BASE}/v1/account/{q(name)}/{q(tag)}")
-            data = acc.get("data", {}) or {}
+            info = await fetch_player_info(name, tag, region=region)
+            data = info.get("account") or {}
             card = data.get("card", {}) or {}
             level = data.get("account_level", 0)
             title = data.get("title") or ""
-
-            mmr = await http_get(f"{HENRIK_BASE}/v2/mmr/{region}/{q(name)}/{q(tag)}")
-            cur = (mmr.get("data") or {}).get("current_data") or {}
+            cur = info.get("current_mmr") or {}
             tier = cur.get("currenttierpatched") or "Unrated"
             rr = cur.get("ranking_in_tier", 0)
 

--- a/cogs/summary.py
+++ b/cogs/summary.py
@@ -6,6 +6,7 @@ from discord import app_commands
 from discord.app_commands import locale_str
 from discord.ext import commands
 
+from core.api import fetch_player_info
 from core.config import HENRIK_BASE, TIERS_DIR
 from core.http import http_get
 from core.store import get_alias, search_aliases, store_match_batch
@@ -84,13 +85,9 @@ class SummaryCog(commands.Cog):
 
         await inter.response.defer()
         try:
-            acc = await http_get(f"{HENRIK_BASE}/v1/account/{q(name)}/{q(tag)}")
-            puuid = (acc.get("data") or {}).get("puuid")
-            if not puuid:
-                raise RuntimeError("Puuid missing in HenrikDev response")
-
-            mmr = await http_get(f"{HENRIK_BASE}/v2/mmr/{region}/{q(name)}/{q(tag)}")
-            cur = (mmr.get("data") or {}).get("current_data") or {}
+            info = await fetch_player_info(name, tag, region=region)
+            puuid = info["puuid"]
+            cur = info.get("current_mmr") or {}
             tier_name = cur.get("currenttierpatched") or "Unrated"
             rr = cur.get("ranking_in_tier", 0)
 

--- a/core/api.py
+++ b/core/api.py
@@ -1,0 +1,57 @@
+"""High-level API helpers for Riot-related lookups."""
+from __future__ import annotations
+
+from typing import Any, Dict, TypedDict
+
+from .config import HENRIK_BASE
+from .http import http_get
+from .utils import is_account_not_found_error, q
+
+
+class PlayerInfo(TypedDict, total=False):
+    """Aggregated account/MMR information for a Riot player."""
+
+    account: Dict[str, Any]
+    mmr: Dict[str, Any]
+    current_mmr: Dict[str, Any]
+    puuid: str
+
+
+async def fetch_player_info(name: str, tag: str, *, region: str) -> PlayerInfo:
+    """Fetch Riot account, PUUID and MMR information for the given player.
+
+    The helper consolidates HTTP requests and normalises error handling so that
+    callers can rely on consistent exceptions (e.g. ``Account not found``).
+    """
+
+    name_q = q(name)
+    tag_q = q(tag)
+
+    try:
+        account_resp = await http_get(f"{HENRIK_BASE}/v1/account/{name_q}/{tag_q}")
+    except Exception as err:  # pragma: no cover - thin wrapper
+        if is_account_not_found_error(err):
+            raise RuntimeError("Account not found") from err
+        raise
+
+    account_data = account_resp.get("data") or {}
+    puuid = account_data.get("puuid")
+    if not puuid:
+        raise RuntimeError("Account not found: missing PUUID")
+
+    try:
+        mmr_resp = await http_get(f"{HENRIK_BASE}/v2/mmr/{region}/{name_q}/{tag_q}")
+    except Exception as err:  # pragma: no cover - thin wrapper
+        if is_account_not_found_error(err):
+            raise RuntimeError("Account not found") from err
+        raise
+
+    mmr_data = mmr_resp.get("data") or {}
+    current = mmr_data.get("current_data") or {}
+
+    return {
+        "account": account_data,
+        "mmr": mmr_data,
+        "current_mmr": current,
+        "puuid": puuid,
+    }


### PR DESCRIPTION
## Summary
- add a core.api helper that fetches Riot account, puuid, and MMR with shared error handling
- refactor the summary, matches, and profile cogs to reuse the helper instead of duplicating HTTP calls

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916caf74268832d83ff3d335c4bd62a)