### PR TITLE
Fix Docker CMD to run bot script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-CMD ["python", "main.py"]
+CMD ["python", "bot.py"]


### PR DESCRIPTION
## Summary
- update the Dockerfile CMD to execute the correct bot entry point

## Testing
- `docker build .` *(fails: docker command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916cb05d3f0832db6785966f744bcf5)