### PR TITLE
Update README instructions for running bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Set `LOG_LEVEL=DEBUG` if you need more verbose console logs while running the bo
 ### 5. Run the bot
 
 ```bash
-python -m bot.py
+python bot.py
 ```
 
 ### 6. Register aliases


### PR DESCRIPTION
## Summary
- replace the README run command with the correct `python bot.py`
- ensure no other incorrect `python -m bot.py` references remain in the documentation

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916cb113008832dbd3a7075348d3e08)