### PR TITLE
Fix matches alias prompt to reference current command name

### DIFF
--- a/cogs/matches.py
+++ b/cogs/matches.py
@@ -61,7 +61,7 @@ class MatchesCog(commands.Cog):
         alias_input = clean_text(target)
         if not alias_input:
             await inter.response.send_message(
-                "별명을 입력해 주세요. 먼저 `/register` 명령으로 Riot ID를 등록할 수 있습니다.",
+                "별명을 입력해 주세요. 먼저 `/별명등록` 명령으로 Riot ID를 등록할 수 있습니다.",
                 ephemeral=True,
             )
             return


### PR DESCRIPTION
## Summary
- update the empty-alias guidance in the recent matches command to refer to `/별명등록`

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916cb1a5d18832d844acd4b170ed295)