### PR TITLE
Fix README run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Set `LOG_LEVEL=DEBUG` if you need more verbose console logs while running the bo
 ### 5. Run the bot
 
 ```bash
-python -m bot.py
+python bot.py
 ```
 
 ### 6. Register aliases


### PR DESCRIPTION
## Summary
- update the run command in the README to use the valid `python bot.py` invocation

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916cb33e85c832d927f3fa34b41d168)