### PR TITLE
Use shared alias registration prompt

### DIFF
--- a/cogs/matches.py
+++ b/cogs/matches.py
@@ -10,6 +10,7 @@ from core.config import HENRIK_BASE
 from core.http import http_get
 from core.store import get_alias, search_aliases, store_match_batch
 from core.utils import (
+    ALIAS_REGISTRATION_PROMPT,
     alias_display,
     check_cooldown,
     clean_text,
@@ -61,7 +62,7 @@ class MatchesCog(commands.Cog):
         alias_input = clean_text(target)
         if not alias_input:
             await inter.response.send_message(
-                "별명을 입력해 주세요. 먼저 `/register` 명령으로 Riot ID를 등록할 수 있습니다.",
+                ALIAS_REGISTRATION_PROMPT,
                 ephemeral=True,
             )
             return

--- a/cogs/profile.py
+++ b/cogs/profile.py
@@ -9,6 +9,7 @@ from core.config import HENRIK_BASE
 from core.http import http_get
 from core.store import get_alias, search_aliases
 from core.utils import (
+    ALIAS_REGISTRATION_PROMPT,
     alias_display,
     check_cooldown,
     clean_text,
@@ -43,7 +44,7 @@ class ProfileCog(commands.Cog):
         alias_input = clean_text(target)
         if not alias_input:
             await inter.response.send_message(
-                "별명을 입력해 주세요. 먼저 `/별명등록` 명령으로 Riot ID를 등록할 수 있습니다.",
+                ALIAS_REGISTRATION_PROMPT,
                 ephemeral=True,
             )
             return

--- a/cogs/summary.py
+++ b/cogs/summary.py
@@ -10,6 +10,7 @@ from core.config import HENRIK_BASE, TIERS_DIR
 from core.http import http_get
 from core.store import get_alias, search_aliases, store_match_batch
 from core.utils import (
+    ALIAS_REGISTRATION_PROMPT,
     alias_display,
     check_cooldown,
     clean_text,
@@ -65,7 +66,7 @@ class SummaryCog(commands.Cog):
         alias_input = clean_text(target)
         if not alias_input:
             await inter.response.send_message(
-                "별명을 입력해 주세요. 먼저 `/별명등록` 명령으로 Riot ID를 등록할 수 있습니다.",
+                ALIAS_REGISTRATION_PROMPT,
                 ephemeral=True,
             )
             return

--- a/core/utils.py
+++ b/core/utils.py
@@ -2,6 +2,10 @@ import time
 import urllib.parse
 from typing import Optional, Dict, Any
 
+ALIAS_REGISTRATION_PROMPT = (
+    "별명을 입력해 주세요. 먼저 `/별명등록` 명령으로 Riot ID를 등록할 수 있습니다."
+)
+
 REGIONS = {"ap","kr","eu","na","br","latam"}
 _COOLDOWN_SEC = 5
 _last_used: dict[int, float] = {}


### PR DESCRIPTION
## Summary
- replace the hard-coded `/register` prompt with the localized `/별명등록` version in the recent matches command
- share the alias registration prompt text across the matches, profile, and summary cogs to keep messaging consistent

## Testing
- python -m compileall .

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916cb3617cc832daa055673d0a87cd6)