### PR TITLE
Update README run command instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,13 @@ Set `LOG_LEVEL=DEBUG` if you need more verbose console logs while running the bo
 
 ### 5. Run the bot
 
+Run the project entrypoint (`bot.py`) with Python:
+
 ```bash
-python -m bot.py
+python bot.py
 ```
+
+> Alternatively, you can use the module form `python -m bot` if you prefer.
 
 ### 6. Register aliases
 


### PR DESCRIPTION
## Summary
- update the README run instructions to use a valid Python invocation
- clarify that `bot.py` is the project entrypoint and mention the module form

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916cb3c1f2c832dada351593e7d508d)