### PR TITLE
Update alias registration prompt to Korean command

### DIFF
--- a/cogs/matches.py
+++ b/cogs/matches.py
@@ -61,7 +61,7 @@ class MatchesCog(commands.Cog):
         alias_input = clean_text(target)
         if not alias_input:
             await inter.response.send_message(
-                "별명을 입력해 주세요. 먼저 `/register` 명령으로 Riot ID를 등록할 수 있습니다.",
+                "별명을 입력해 주세요. 먼저 `/별명등록` 명령으로 Riot ID를 등록할 수 있습니다.",
                 ephemeral=True,
             )
             return


### PR DESCRIPTION
## Summary
- reference the /별명등록 command in the missing-alias prompt for the 최근경기 command

## Testing
- python - <<'PY'
from pathlib import Path
text = Path('cogs/matches.py').read_text(encoding='utf-8')
if "`/별명등록`" not in text:
    raise SystemExit('string not updated')
print('String updated correctly')
PY

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916cb3edf24832d96bd339be3e83c1f)