### PR TITLE
Optimize tier fetching in alias list command

### DIFF
--- a/cogs/register.py
+++ b/cogs/register.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Optional, List, Tuple, Dict, Any
 
 import discord
@@ -138,9 +139,31 @@ class RegisterCog(commands.Cog):
 
         await inter.response.defer()
 
+        tier_tasks: Dict[Tuple[str, str, str], asyncio.Task] = {}
+        semaphore = asyncio.Semaphore(3)
+
+        async def fetch_tier_with_cache(record: Dict[str, Any]) -> Tuple[str, Optional[str]]:
+            key = (
+                record.get("region", "ap"),
+                record.get("name", ""),
+                record.get("tag", ""),
+            )
+            task = tier_tasks.get(key)
+            if task is None:
+                async def _task() -> Tuple[str, Optional[str]]:
+                    async with semaphore:
+                        return await self._fetch_tier(record)
+
+                task = asyncio.create_task(_task())
+                tier_tasks[key] = task
+            return await task
+
+        tier_results = await asyncio.gather(
+            *(fetch_tier_with_cache(rec) for rec in records)
+        )
+
         embeds_payload: List[Tuple[discord.Embed, Optional[str]]] = []
-        for rec in records:
-            tier_name, image_url = await self._fetch_tier(rec)
+        for rec, (tier_name, image_url) in zip(records, tier_results):
             embed = discord.Embed(
                 description=f"**{rec['name']}#{rec['tag']}** ({rec['region'].upper()})",
                 color=discord.Color.blurple(),


### PR DESCRIPTION
## Summary
- cache tier lookups and gather them concurrently to reduce redundant Henrik API requests
- limit concurrent Henrik API calls to respect rate limits while retaining local tier image fallbacks

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916cb407134832d802ad2f2faf174c0)