### PR TITLE
Fix recent match summary metadata parsing

### DIFF
--- a/cogs/alerts.py
+++ b/cogs/alerts.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Dict, Optional, List, Tuple, Any
+from typing import Any, Dict, List, Optional, Tuple
 
 import discord
 from discord.ext import commands, tasks
@@ -13,10 +13,44 @@ from core.store import (
     store_match_batch,
     list_alert_channels,
 )
-from core.utils import q
+from core.utils import clean_text, metadata_label, q
 
 
 log = logging.getLogger(__name__)
+
+
+def _find_player(
+    all_players: List[Dict[str, Any]],
+    *,
+    puuid: Optional[str],
+    name: Optional[str] = None,
+    tag: Optional[str] = None,
+):
+    puuid_norm = clean_text(puuid).lower() if puuid else ""
+    if puuid_norm:
+        for player in all_players:
+            candidate = clean_text(player.get("puuid")).lower()
+            if candidate and candidate == puuid_norm:
+                return player
+
+    name_norm = clean_text(name).lower()
+    tag_norm = clean_text(tag).upper()
+    if name_norm and tag_norm:
+        for player in all_players:
+            player_name = clean_text(
+                player.get("game_name")
+                or player.get("gameName")
+                or player.get("name")
+            ).lower()
+            player_tag = clean_text(
+                player.get("tag_line")
+                or player.get("tagLine")
+                or player.get("tag")
+            ).upper()
+            if player_name == name_norm and player_tag == tag_norm:
+                return player
+
+    return None
 
 
 class AlertCog(commands.Cog):
@@ -98,10 +132,10 @@ class AlertCog(commands.Cog):
 
     def _build_embed(self, entry: Dict[str, Any], match: Dict[str, Any], match_id: str) -> discord.Embed:
         metadata = match.get("metadata") or {}
-        map_name = metadata.get("map", "?")
-        mode_name = metadata.get("mode", "?")
+        map_name = metadata_label(metadata, "map")
+        mode_name = metadata_label(metadata, "mode")
         started = metadata.get("game_start_patched") or metadata.get("game_start") or "Unknown"
-        player_stats, outcome = self._extract_player_stats(entry.get("puuid"), match)
+        player_stats, outcome = self._extract_player_stats(entry, match)
 
         color = discord.Color.from_rgb(149, 165, 166)  # default grey
         result_label = "결과 정보 없음"
@@ -135,11 +169,20 @@ class AlertCog(commands.Cog):
         embed.url = f"https://tracker.gg/valorant/match/{match_id}"
         return embed
 
-    def _extract_player_stats(self, puuid: Optional[str], match: Dict[str, Any]) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
-        if not puuid:
+    def _extract_player_stats(
+        self, entry: Dict[str, Any], match: Dict[str, Any]
+    ) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+        puuid = entry.get("puuid")
+        if not puuid and not entry.get("name"):
             return None, None
+
         players = (match.get("players") or {}).get("all_players") or []
-        me = next((p for p in players if p.get("puuid") == puuid), None)
+        me = _find_player(
+            players,
+            puuid=puuid,
+            name=entry.get("name"),
+            tag=entry.get("tag"),
+        )
         if me is None:
             return None, None
 

--- a/cogs/matches.py
+++ b/cogs/matches.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import discord
 from discord import app_commands
@@ -17,8 +17,42 @@ from core.utils import (
     clean_text,
     format_exception_message,
     is_account_not_found_error,
+    metadata_label,
     q,
 )
+
+def _find_player(
+    all_players: List[Dict[str, Any]],
+    *,
+    puuid: Optional[str],
+    name: str,
+    tag: str,
+):
+    puuid_norm = clean_text(puuid).lower() if puuid else ""
+    if puuid_norm:
+        for player in all_players:
+            candidate = clean_text(player.get("puuid")).lower()
+            if candidate and candidate == puuid_norm:
+                return player
+
+    name_norm = clean_text(name).lower()
+    tag_norm = clean_text(tag).upper()
+    if name_norm and tag_norm:
+        for player in all_players:
+            player_name = clean_text(
+                player.get("game_name")
+                or player.get("gameName")
+                or player.get("name")
+            ).lower()
+            player_tag = clean_text(
+                player.get("tag_line")
+                or player.get("tagLine")
+                or player.get("tag")
+            ).upper()
+            if player_name == name_norm and player_tag == tag_norm:
+                return player
+
+    return None
 
 
 class MatchesCog(commands.Cog):
@@ -112,16 +146,16 @@ class MatchesCog(commands.Cog):
 
             lines = []
             for match in matches:
-                metadata = match.get("metadata", {}) or {}
-                map_name = metadata.get("map", "?")
-                mode_name = metadata.get("mode", "?")
+                metadata = match.get("metadata") or {}
+                map_name = metadata_label(metadata, "map")
+                mode_name = metadata_label(metadata, "mode")
 
                 all_players = (match.get("players") or {}).get("all_players") or []
-                me = next((p for p in all_players if p.get("puuid") == puuid), None)
+                me = _find_player(all_players, puuid=puuid, name=name, tag=tag)
                 stats = (me or {}).get("stats") or {}
-                k = stats.get("kills", 0)
-                d = stats.get("deaths", 0)
-                a = stats.get("assists", 0)
+                k = int(stats.get("kills") or 0)
+                d = int(stats.get("deaths") or 0)
+                a = int(stats.get("assists") or 0)
 
                 result = "?"
                 team = me.get("team") if me else None

--- a/core/store.py
+++ b/core/store.py
@@ -4,6 +4,7 @@ import time
 from typing import Any, Dict, Iterable, List, Tuple, Optional
 
 from .config import DB_FILE
+from .utils import metadata_label
 
 
 def _connect() -> sqlite3.Connection:
@@ -219,8 +220,8 @@ def store_match_batch(owner_key: str, puuid: str, matches: Iterable[Dict[str, An
                 result = "loss"
 
         played_at = metadata.get("game_start_patched") or metadata.get("game_start")
-        map_name = metadata.get("map")
-        mode_name = metadata.get("mode")
+        map_name = metadata_label(metadata, "map", default=None)
+        mode_name = metadata_label(metadata, "mode", default=None)
 
         raw_json = json.dumps(match, ensure_ascii=False)
         rows.append(

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -51,6 +51,26 @@ class StoreMatchBatchTests(unittest.TestCase):
         repeated = store.store_match_batch(owner_key, puuid, [match])
         self.assertEqual(repeated, 0)
 
+    def test_handles_nested_metadata_labels(self) -> None:
+        owner_key = "alias:test"
+        puuid = "test-puuid"
+        match = _sample_match("match-2", puuid)
+        match["metadata"]["map"] = {
+            "name": "Sunset",
+            "localized": {"ko-KR": "선셋"},
+        }
+        match["metadata"]["mode"] = {
+            "localized": {"en-US": "Swiftplay"},
+        }
+
+        inserted = store.store_match_batch(owner_key, puuid, [match])
+        self.assertEqual(inserted, 1)
+
+        latest = store.latest_match(owner_key)
+        self.assertIsNotNone(latest)
+        self.assertEqual(latest["map"], "Sunset")
+        self.assertEqual(latest["mode"], "Swiftplay")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- normalize map and mode metadata to handle nested values in Henrik responses
- fall back to Riot ID matching when puuid is missing so K/D/A is displayed
- update alerts embed and add coverage for nested metadata storage

## Testing
- PYTHONPATH=. pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916d64264fc832d87fd74662a1034a4)